### PR TITLE
Move facets to footer.

### DIFF
--- a/config/install/views.view.solr_search_content.yml
+++ b/config/install/views.view.solr_search_content.yml
@@ -599,50 +599,6 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-        field_external_uri_2:
-          id: field_external_uri_2
-          table: search_api_index_default_solr_index
-          field: field_external_uri_2
-          relationship: none
-          group_type: group
-          admin_label: ''
-          plugin_id: search_api_string
-          operator: '!='
-          value:
-            min: ''
-            max: ''
-            value: 'http://purl.org/dc/dcmitype/Collection#Model'
-          group: 1
-          exposed: false
-          expose:
-            operator_id: ''
-            label: ''
-            description: ''
-            use_operator: false
-            operator: ''
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: ''
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-            min_placeholder: ''
-            max_placeholder: ''
-            placeholder: ''
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
         field_external_uri_2_1:
           id: field_external_uri_2_1
           table: search_api_index_default_solr_index

--- a/config/install/views.view.solr_search_content.yml
+++ b/config/install/views.view.solr_search_content.yml
@@ -1124,6 +1124,157 @@ display:
           plugin_id: views_block_area
           empty: false
           block_id: 'facets_summary_block:active_filters'
+      footer:
+        views_block_area_1:
+          id: views_block_area_1
+          table: views
+          field: views_block_area
+          relationship: none
+          group_type: group
+          admin_label: 'Facet - Agent By Role: Consultant (csl)'
+          plugin_id: views_block_area
+          empty: false
+          block_id: 'facet_block:agent_by_role_consultant_csl_'
+        views_block_area_2:
+          id: views_block_area_2
+          table: views
+          field: views_block_area
+          relationship: none
+          group_type: group
+          admin_label: 'Facet - Agent By Role: Contributor (ctb)'
+          plugin_id: views_block_area
+          empty: false
+          block_id: 'facet_block:agent_by_role_contributor_ctb_'
+        views_block_area_3:
+          id: views_block_area_3
+          table: views
+          field: views_block_area
+          relationship: none
+          group_type: group
+          admin_label: 'Facet - Agent By Role: Creator (cre)'
+          plugin_id: views_block_area
+          empty: false
+          block_id: 'facet_block:agent_by_role_creator_cre_'
+        views_block_area_4:
+          id: views_block_area_4
+          table: views
+          field: views_block_area
+          relationship: none
+          group_type: group
+          admin_label: 'Facet - Agent By Role: Publisher (pbl)'
+          plugin_id: views_block_area
+          empty: false
+          block_id: 'facet_block:agent_by_role_publisher_pbl_'
+        views_block_area_5:
+          id: views_block_area_5
+          table: views
+          field: views_block_area
+          relationship: none
+          group_type: group
+          admin_label: 'Facet - Author Name'
+          plugin_id: views_block_area
+          empty: false
+          block_id: 'facet_block:author_name'
+        views_block_area_6:
+          id: views_block_area_6
+          table: views
+          field: views_block_area
+          relationship: none
+          group_type: group
+          admin_label: 'Facet - Date Created'
+          plugin_id: views_block_area
+          empty: false
+          block_id: 'facet_block:date_created'
+        views_block_area_7:
+          id: views_block_area_7
+          table: views
+          field: views_block_area
+          relationship: none
+          group_type: group
+          admin_label: 'Facet - Date Issued'
+          plugin_id: views_block_area
+          empty: false
+          block_id: 'facet_block:date_issued'
+        views_block_area_8:
+          id: views_block_area_8
+          table: views
+          field: views_block_area
+          relationship: none
+          group_type: group
+          admin_label: 'Facet - Genre'
+          plugin_id: views_block_area
+          empty: false
+          block_id: 'facet_block:genre'
+        views_block_area_9:
+          id: views_block_area_9
+          table: views
+          field: views_block_area
+          relationship: none
+          group_type: group
+          admin_label: 'Facet - Identifier'
+          plugin_id: views_block_area
+          empty: false
+          block_id: 'facet_block:identifier'
+        views_block_area_10:
+          id: views_block_area_10
+          table: views
+          field: views_block_area
+          relationship: none
+          group_type: group
+          admin_label: 'Facet - Member Of'
+          plugin_id: views_block_area
+          empty: false
+          block_id: 'facet_block:member_of_content_title'
+        views_block_area_11:
+          id: views_block_area_11
+          table: views
+          field: views_block_area
+          relationship: none
+          group_type: group
+          admin_label: 'Facet - Model'
+          plugin_id: views_block_area
+          empty: false
+          block_id: 'facet_block:model_'
+        views_block_area_12:
+          id: views_block_area_12
+          table: views
+          field: views_block_area
+          relationship: none
+          group_type: group
+          admin_label: 'Facet - Physical Form'
+          plugin_id: views_block_area
+          empty: false
+          block_id: 'facet_block:physical_form'
+        views_block_area_13:
+          id: views_block_area_13
+          table: views
+          field: views_block_area
+          relationship: none
+          group_type: group
+          admin_label: 'Facet - Place Published'
+          plugin_id: views_block_area
+          empty: false
+          block_id: 'facet_block:place_published'
+        views_block_area_14:
+          id: views_block_area_14
+          table: views
+          field: views_block_area
+          relationship: none
+          group_type: group
+          admin_label: 'Facet - Subject'
+          plugin_id: views_block_area
+          empty: false
+          block_id: 'facet_block:subject'
+        views_block_area_15:
+          id: views_block_area_15
+          table: views
+          field: views_block_area
+          relationship: none
+          group_type: group
+          admin_label: 'Facet - Subject Name'
+          plugin_id: views_block_area
+          empty: false
+          block_id: 'facet_block:subject_name'
       exposed_block: true
       display_extenders: {  }
       path: solr-search/content

--- a/config/install/views.view.solr_search_content.yml
+++ b/config/install/views.view.solr_search_content.yml
@@ -335,7 +335,157 @@ display:
           table: views
           field: views_block_area
           plugin_id: views_block_area
-      footer: {  }
+      footer:
+        views_block_area_1:
+          id: views_block_area_1
+          table: views
+          field: views_block_area
+          relationship: none
+          group_type: group
+          admin_label: 'Facet - Agent By Role: Consultant (csl)'
+          plugin_id: views_block_area
+          empty: false
+          block_id: 'facet_block:agent_by_role_consultant_csl_'
+        views_block_area_2:
+          id: views_block_area_2
+          table: views
+          field: views_block_area
+          relationship: none
+          group_type: group
+          admin_label: 'Facet - Agent By Role: Contributor (ctb)'
+          plugin_id: views_block_area
+          empty: false
+          block_id: 'facet_block:agent_by_role_contributor_ctb_'
+        views_block_area_3:
+          id: views_block_area_3
+          table: views
+          field: views_block_area
+          relationship: none
+          group_type: group
+          admin_label: 'Facet - Agent By Role: Creator (cre)'
+          plugin_id: views_block_area
+          empty: false
+          block_id: 'facet_block:agent_by_role_creator_cre_'
+        views_block_area_4:
+          id: views_block_area_4
+          table: views
+          field: views_block_area
+          relationship: none
+          group_type: group
+          admin_label: 'Facet - Agent By Role: Publisher (pbl)'
+          plugin_id: views_block_area
+          empty: false
+          block_id: 'facet_block:agent_by_role_publisher_pbl_'
+        views_block_area_5:
+          id: views_block_area_5
+          table: views
+          field: views_block_area
+          relationship: none
+          group_type: group
+          admin_label: 'Facet - Author Name'
+          plugin_id: views_block_area
+          empty: false
+          block_id: 'facet_block:author_name'
+        views_block_area_6:
+          id: views_block_area_6
+          table: views
+          field: views_block_area
+          relationship: none
+          group_type: group
+          admin_label: 'Facet - Date Created'
+          plugin_id: views_block_area
+          empty: false
+          block_id: 'facet_block:date_created'
+        views_block_area_7:
+          id: views_block_area_7
+          table: views
+          field: views_block_area
+          relationship: none
+          group_type: group
+          admin_label: 'Facet - Date Issued'
+          plugin_id: views_block_area
+          empty: false
+          block_id: 'facet_block:date_issued'
+        views_block_area_8:
+          id: views_block_area_8
+          table: views
+          field: views_block_area
+          relationship: none
+          group_type: group
+          admin_label: 'Facet - Genre'
+          plugin_id: views_block_area
+          empty: false
+          block_id: 'facet_block:genre'
+        views_block_area_9:
+          id: views_block_area_9
+          table: views
+          field: views_block_area
+          relationship: none
+          group_type: group
+          admin_label: 'Facet - Identifier'
+          plugin_id: views_block_area
+          empty: false
+          block_id: 'facet_block:identifier'
+        views_block_area_10:
+          id: views_block_area_10
+          table: views
+          field: views_block_area
+          relationship: none
+          group_type: group
+          admin_label: 'Facet - Member Of'
+          plugin_id: views_block_area
+          empty: false
+          block_id: 'facet_block:member_of_content_title'
+        views_block_area_11:
+          id: views_block_area_11
+          table: views
+          field: views_block_area
+          relationship: none
+          group_type: group
+          admin_label: 'Facet - Model'
+          plugin_id: views_block_area
+          empty: false
+          block_id: 'facet_block:model_'
+        views_block_area_12:
+          id: views_block_area_12
+          table: views
+          field: views_block_area
+          relationship: none
+          group_type: group
+          admin_label: 'Facet - Physical Form'
+          plugin_id: views_block_area
+          empty: false
+          block_id: 'facet_block:physical_form'
+        views_block_area_13:
+          id: views_block_area_13
+          table: views
+          field: views_block_area
+          relationship: none
+          group_type: group
+          admin_label: 'Facet - Place Published'
+          plugin_id: views_block_area
+          empty: false
+          block_id: 'facet_block:place_published'
+        views_block_area_14:
+          id: views_block_area_14
+          table: views
+          field: views_block_area
+          relationship: none
+          group_type: group
+          admin_label: 'Facet - Subject'
+          plugin_id: views_block_area
+          empty: false
+          block_id: 'facet_block:subject'
+        views_block_area_15:
+          id: views_block_area_15
+          table: views
+          field: views_block_area
+          relationship: none
+          group_type: group
+          admin_label: 'Facet - Subject Name'
+          plugin_id: views_block_area
+          empty: false
+          block_id: 'facet_block:subject_name'
       display_extenders: {  }
     cache_metadata:
       max-age: -1
@@ -743,156 +893,6 @@ display:
           plugin_id: result
           empty: true
           content: 'Displaying results @start - @end of @total'
-        views_block_area:
-          id: views_block_area
-          table: views
-          field: views_block_area
-          relationship: none
-          group_type: group
-          admin_label: 'Facets Summary'
-          plugin_id: views_block_area
-          empty: false
-          block_id: 'facets_summary_block:facet_summary'
-        views_block_area_1:
-          id: views_block_area_1
-          table: views
-          field: views_block_area
-          relationship: none
-          group_type: group
-          admin_label: 'Facet - Agent By Role: Consultant (csl)'
-          plugin_id: views_block_area
-          empty: false
-          block_id: 'facet_block:agent_by_role_consultant_csl_block'
-        views_block_area_2:
-          id: views_block_area_2
-          table: views
-          field: views_block_area
-          relationship: none
-          group_type: group
-          admin_label: 'Facet - Agent By Role: Contributor (ctb)'
-          plugin_id: views_block_area
-          empty: false
-          block_id: 'facet_block:duplicate_of_agent_by_role_contributor_ctb_block'
-        views_block_area_3:
-          id: views_block_area_3
-          table: views
-          field: views_block_area
-          relationship: none
-          group_type: group
-          admin_label: 'Facet - Agent By Role: Creator (cre)'
-          plugin_id: views_block_area
-          empty: false
-          block_id: 'facet_block:agent_by_role_creator_cre_block'
-        views_block_area_4:
-          id: views_block_area_4
-          table: views
-          field: views_block_area
-          relationship: none
-          group_type: group
-          admin_label: 'Facet - Agent By Role: Publisher (pbl)'
-          plugin_id: views_block_area
-          empty: false
-          block_id: 'facet_block:agent_by_role_publisher_pbl_block'
-        views_block_area_5:
-          id: views_block_area_5
-          table: views
-          field: views_block_area
-          relationship: none
-          group_type: group
-          admin_label: 'Facet - Author Name'
-          plugin_id: views_block_area
-          empty: false
-          block_id: 'facet_block:duplicate_of_author_name_block'
-        views_block_area_6:
-          id: views_block_area_6
-          table: views
-          field: views_block_area
-          relationship: none
-          group_type: group
-          admin_label: 'Facet - Date Created'
-          plugin_id: views_block_area
-          empty: false
-          block_id: 'facet_block:duplicate_of_date_created_block'
-        views_block_area_7:
-          id: views_block_area_7
-          table: views
-          field: views_block_area
-          relationship: none
-          group_type: group
-          admin_label: 'Facet - Date Issued'
-          plugin_id: views_block_area
-          empty: false
-          block_id: 'facet_block:date_issued_block'
-        views_block_area_8:
-          id: views_block_area_8
-          table: views
-          field: views_block_area
-          relationship: none
-          group_type: group
-          admin_label: 'Facet - Genre'
-          plugin_id: views_block_area
-          empty: false
-          block_id: 'facet_block:genre_block'
-        views_block_area_9:
-          id: views_block_area_9
-          table: views
-          field: views_block_area
-          relationship: none
-          group_type: group
-          admin_label: 'Facet - Identifier'
-          plugin_id: views_block_area
-          empty: false
-          block_id: 'facet_block:identifier_block'
-        views_block_area_10:
-          id: views_block_area_10
-          table: views
-          field: views_block_area
-          relationship: none
-          group_type: group
-          admin_label: 'Facet - Language'
-          plugin_id: views_block_area
-          empty: false
-          block_id: 'facet_block:language_block'
-        views_block_area_11:
-          id: views_block_area_11
-          table: views
-          field: views_block_area
-          relationship: none
-          group_type: group
-          admin_label: 'Facet - Member Of'
-          plugin_id: views_block_area
-          empty: false
-          block_id: 'facet_block:member_of_block'
-        views_block_area_12:
-          id: views_block_area_12
-          table: views
-          field: views_block_area
-          relationship: none
-          group_type: group
-          admin_label: 'Facet - Physical Form'
-          plugin_id: views_block_area
-          empty: false
-          block_id: 'facet_block:physical_form_block'
-        views_block_area_13:
-          id: views_block_area_13
-          table: views
-          field: views_block_area
-          relationship: none
-          group_type: group
-          admin_label: 'Facet - Subject'
-          plugin_id: views_block_area
-          empty: false
-          block_id: 'facet_block:subject_block'
-        views_block_area_14:
-          id: views_block_area_14
-          table: views
-          field: views_block_area
-          relationship: none
-          group_type: group
-          admin_label: 'Facet - Subject Name'
-          plugin_id: views_block_area
-          empty: false
-          block_id: 'facet_block:subject_name_block'
       display_extenders: {  }
     cache_metadata:
       max-age: -1
@@ -1124,156 +1124,6 @@ display:
           plugin_id: views_block_area
           empty: false
           block_id: 'facets_summary_block:active_filters'
-        views_block_area_1:
-          id: views_block_area_1
-          table: views
-          field: views_block_area
-          relationship: none
-          group_type: group
-          admin_label: 'Facet - Agent By Role: Consultant (csl)'
-          plugin_id: views_block_area
-          empty: false
-          block_id: 'facet_block:agent_by_role_consultant_csl_'
-        views_block_area_2:
-          id: views_block_area_2
-          table: views
-          field: views_block_area
-          relationship: none
-          group_type: group
-          admin_label: 'Facet - Agent By Role: Contributor (ctb)'
-          plugin_id: views_block_area
-          empty: false
-          block_id: 'facet_block:agent_by_role_contributor_ctb_'
-        views_block_area_3:
-          id: views_block_area_3
-          table: views
-          field: views_block_area
-          relationship: none
-          group_type: group
-          admin_label: 'Facet - Agent By Role: Creator (cre)'
-          plugin_id: views_block_area
-          empty: false
-          block_id: 'facet_block:agent_by_role_creator_cre_'
-        views_block_area_4:
-          id: views_block_area_4
-          table: views
-          field: views_block_area
-          relationship: none
-          group_type: group
-          admin_label: 'Facet - Agent By Role: Publisher (pbl)'
-          plugin_id: views_block_area
-          empty: false
-          block_id: 'facet_block:agent_by_role_publisher_pbl_'
-        views_block_area_5:
-          id: views_block_area_5
-          table: views
-          field: views_block_area
-          relationship: none
-          group_type: group
-          admin_label: 'Facet - Author Name'
-          plugin_id: views_block_area
-          empty: false
-          block_id: 'facet_block:author_name'
-        views_block_area_6:
-          id: views_block_area_6
-          table: views
-          field: views_block_area
-          relationship: none
-          group_type: group
-          admin_label: 'Facet - Date Created'
-          plugin_id: views_block_area
-          empty: false
-          block_id: 'facet_block:date_created'
-        views_block_area_7:
-          id: views_block_area_7
-          table: views
-          field: views_block_area
-          relationship: none
-          group_type: group
-          admin_label: 'Facet - Date Issued'
-          plugin_id: views_block_area
-          empty: false
-          block_id: 'facet_block:date_issued'
-        views_block_area_8:
-          id: views_block_area_8
-          table: views
-          field: views_block_area
-          relationship: none
-          group_type: group
-          admin_label: 'Facet - Genre'
-          plugin_id: views_block_area
-          empty: false
-          block_id: 'facet_block:genre'
-        views_block_area_9:
-          id: views_block_area_9
-          table: views
-          field: views_block_area
-          relationship: none
-          group_type: group
-          admin_label: 'Facet - Identifier'
-          plugin_id: views_block_area
-          empty: false
-          block_id: 'facet_block:identifier'
-        views_block_area_10:
-          id: views_block_area_10
-          table: views
-          field: views_block_area
-          relationship: none
-          group_type: group
-          admin_label: 'Facet - Member Of'
-          plugin_id: views_block_area
-          empty: false
-          block_id: 'facet_block:member_of_content_title'
-        views_block_area_11:
-          id: views_block_area_11
-          table: views
-          field: views_block_area
-          relationship: none
-          group_type: group
-          admin_label: 'Facet - Model'
-          plugin_id: views_block_area
-          empty: false
-          block_id: 'facet_block:model_'
-        views_block_area_12:
-          id: views_block_area_12
-          table: views
-          field: views_block_area
-          relationship: none
-          group_type: group
-          admin_label: 'Facet - Physical Form'
-          plugin_id: views_block_area
-          empty: false
-          block_id: 'facet_block:physical_form'
-        views_block_area_13:
-          id: views_block_area_13
-          table: views
-          field: views_block_area
-          relationship: none
-          group_type: group
-          admin_label: 'Facet - Place Published'
-          plugin_id: views_block_area
-          empty: false
-          block_id: 'facet_block:place_published'
-        views_block_area_14:
-          id: views_block_area_14
-          table: views
-          field: views_block_area
-          relationship: none
-          group_type: group
-          admin_label: 'Facet - Subject'
-          plugin_id: views_block_area
-          empty: false
-          block_id: 'facet_block:subject'
-        views_block_area_15:
-          id: views_block_area_15
-          table: views
-          field: views_block_area
-          relationship: none
-          group_type: group
-          admin_label: 'Facet - Subject Name'
-          plugin_id: views_block_area
-          empty: false
-          block_id: 'facet_block:subject_name'
       exposed_block: true
       display_extenders: {  }
       path: solr-search/content
@@ -1290,3 +1140,4 @@ display:
       tags:
         - 'config:field.storage.node.field_display_title'
         - 'config:search_api.index.default_solr_index'
+

--- a/config/install/views.view.solr_search_content.yml
+++ b/config/install/views.view.solr_search_content.yml
@@ -330,12 +330,17 @@ display:
           plugin_id: result
           empty: true
           content: 'Displaying results @start - @end of @total'
+      footer:
         views_block_area:
           id: views_block_area
           table: views
           field: views_block_area
+          relationship: none
+          group_type: group
+          admin_label: 'Facets Summary'
           plugin_id: views_block_area
-      footer:
+          empty: false
+          block_id: 'facets_summary_block:facet_summary'
         views_block_area_1:
           id: views_block_area_1
           table: views
@@ -345,7 +350,7 @@ display:
           admin_label: 'Facet - Agent By Role: Consultant (csl)'
           plugin_id: views_block_area
           empty: false
-          block_id: 'facet_block:agent_by_role_consultant_csl_'
+          block_id: 'facet_block:agent_by_role_consultant_csl_block'
         views_block_area_2:
           id: views_block_area_2
           table: views
@@ -355,7 +360,7 @@ display:
           admin_label: 'Facet - Agent By Role: Contributor (ctb)'
           plugin_id: views_block_area
           empty: false
-          block_id: 'facet_block:agent_by_role_contributor_ctb_'
+          block_id: 'facet_block:duplicate_of_agent_by_role_contributor_ctb_block'
         views_block_area_3:
           id: views_block_area_3
           table: views
@@ -365,7 +370,7 @@ display:
           admin_label: 'Facet - Agent By Role: Creator (cre)'
           plugin_id: views_block_area
           empty: false
-          block_id: 'facet_block:agent_by_role_creator_cre_'
+          block_id: 'facet_block:agent_by_role_creator_cre_block'
         views_block_area_4:
           id: views_block_area_4
           table: views
@@ -375,7 +380,7 @@ display:
           admin_label: 'Facet - Agent By Role: Publisher (pbl)'
           plugin_id: views_block_area
           empty: false
-          block_id: 'facet_block:agent_by_role_publisher_pbl_'
+          block_id: 'facet_block:agent_by_role_publisher_pbl_block'
         views_block_area_5:
           id: views_block_area_5
           table: views
@@ -385,7 +390,7 @@ display:
           admin_label: 'Facet - Author Name'
           plugin_id: views_block_area
           empty: false
-          block_id: 'facet_block:author_name'
+          block_id: 'facet_block:duplicate_of_author_name_block'
         views_block_area_6:
           id: views_block_area_6
           table: views
@@ -395,7 +400,7 @@ display:
           admin_label: 'Facet - Date Created'
           plugin_id: views_block_area
           empty: false
-          block_id: 'facet_block:date_created'
+          block_id: 'facet_block:duplicate_of_date_created_block'
         views_block_area_7:
           id: views_block_area_7
           table: views
@@ -405,7 +410,7 @@ display:
           admin_label: 'Facet - Date Issued'
           plugin_id: views_block_area
           empty: false
-          block_id: 'facet_block:date_issued'
+          block_id: 'facet_block:date_issued_block'
         views_block_area_8:
           id: views_block_area_8
           table: views
@@ -415,7 +420,7 @@ display:
           admin_label: 'Facet - Genre'
           plugin_id: views_block_area
           empty: false
-          block_id: 'facet_block:genre'
+          block_id: 'facet_block:genre_block'
         views_block_area_9:
           id: views_block_area_9
           table: views
@@ -425,7 +430,7 @@ display:
           admin_label: 'Facet - Identifier'
           plugin_id: views_block_area
           empty: false
-          block_id: 'facet_block:identifier'
+          block_id: 'facet_block:identifier_block'
         views_block_area_10:
           id: views_block_area_10
           table: views
@@ -435,19 +440,9 @@ display:
           admin_label: 'Facet - Member Of'
           plugin_id: views_block_area
           empty: false
-          block_id: 'facet_block:member_of_content_title'
+          block_id: 'facet_block:member_of_block'
         views_block_area_11:
           id: views_block_area_11
-          table: views
-          field: views_block_area
-          relationship: none
-          group_type: group
-          admin_label: 'Facet - Model'
-          plugin_id: views_block_area
-          empty: false
-          block_id: 'facet_block:model_'
-        views_block_area_12:
-          id: views_block_area_12
           table: views
           field: views_block_area
           relationship: none
@@ -455,9 +450,9 @@ display:
           admin_label: 'Facet - Physical Form'
           plugin_id: views_block_area
           empty: false
-          block_id: 'facet_block:physical_form'
-        views_block_area_13:
-          id: views_block_area_13
+          block_id: 'facet_block:physical_form_block'
+        views_block_area_12:
+          id: views_block_area_12
           table: views
           field: views_block_area
           relationship: none
@@ -465,9 +460,9 @@ display:
           admin_label: 'Facet - Place Published'
           plugin_id: views_block_area
           empty: false
-          block_id: 'facet_block:place_published'
-        views_block_area_14:
-          id: views_block_area_14
+          block_id: 'facet_block:place_publishe_block'
+        views_block_area_13:
+          id: views_block_area_13
           table: views
           field: views_block_area
           relationship: none
@@ -475,9 +470,9 @@ display:
           admin_label: 'Facet - Subject'
           plugin_id: views_block_area
           empty: false
-          block_id: 'facet_block:subject'
-        views_block_area_15:
-          id: views_block_area_15
+          block_id: 'facet_block:subject_block'
+        views_block_area_14:
+          id: views_block_area_14
           table: views
           field: views_block_area
           relationship: none
@@ -485,7 +480,7 @@ display:
           admin_label: 'Facet - Subject Name'
           plugin_id: views_block_area
           empty: false
-          block_id: 'facet_block:subject_name'
+          block_id: 'facet_block:subject_name_block'
       display_extenders: {  }
     cache_metadata:
       max-age: -1
@@ -1102,6 +1097,7 @@ display:
         filters: false
         filter_groups: false
         header: false
+        footer: false
       display_description: ''
       header:
         result:
@@ -1114,6 +1110,7 @@ display:
           plugin_id: result
           empty: true
           content: "<h1 class=\"view-title\">Search Results</h1>\r\nDisplaying results @start - @end of @total"
+      footer:
         views_block_area:
           id: views_block_area
           table: views
@@ -1124,7 +1121,6 @@ display:
           plugin_id: views_block_area
           empty: false
           block_id: 'facets_summary_block:active_filters'
-      footer:
         views_block_area_1:
           id: views_block_area_1
           table: views
@@ -1291,4 +1287,3 @@ display:
       tags:
         - 'config:field.storage.node.field_display_title'
         - 'config:search_api.index.default_solr_index'
-


### PR DESCRIPTION
Move facet info to the footer of the block. Sorry this took me so long, I tried a million ways that didn't work to get these to show up in the footer. If you have  a working site with demo content and the install profile, testing should be as easy as loading this YML through config sync and seeing that the facets start showing at the bottom instead of the top, whenever a search view is rendered.

I don't know that using the "header" and "footer" view regions is the best long term solution for placing facet blocks. I do know that doing it this way makes it a little less theme  dependent. 

@Natkeeran @kstapelfeldt 