### PR TITLE
add fancy redirect for 403 errors

### DIFF
--- a/config/install/system.site.yml
+++ b/config/install/system.site.yml
@@ -3,7 +3,7 @@ mail: admin@example.com
 slogan: 'Islandora Digital Collections'
 page:
   front: /node/1
-  403: ''
+  403: '/user/login?destination=document.location.pathname'
   404: ''
 admin_compact_mode: false
 weight_select_max: 100


### PR DESCRIPTION
When navigating to a 403 page, this adds a redirect to login then  back to the original page that triggered the login.

## Current behavior
- Start as an anonymous user
- Go to /admin
- Get a 403 error page

## Behavior from this PR
- Start as an anonymous user
- Go to /admin
- Get redirected to log in page
- Log in
- Redirected back to /admin
