### PR TITLE
Upgrade facets to ^2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -103,7 +103,7 @@
         "drupal/devel": "^4.1",
         "drupal/ds": "^3.13",
         "drupal/environment_indicator": "^4.0",
-        "drupal/facets": "^1.8",
+        "drupal/facets": "^2.0",
         "drupal/features": "^3.11",
         "drupal/file_download_link": "^1.1",
 	"drupal/fixed_block_content": "^1.1",


### PR DESCRIPTION
 Works with Drupal: ^9.2 || ^10.0 

Facets 8.x-1.8 is not supported on ^9.2 only ^9.0


Without this change, cannot update drupal/facets in ISLE