### PR TITLE
fixed block name that is referenced in the solr search view

### DIFF
--- a/config/install/views.view.solr_search_content.yml
+++ b/config/install/views.view.solr_search_content.yml
@@ -460,7 +460,7 @@ display:
           admin_label: 'Facet - Place Published'
           plugin_id: views_block_area
           empty: false
-          block_id: 'facet_block:place_publishe_block'
+          block_id: 'facet_block:place_published_block'
         views_block_area_13:
           id: views_block_area_13
           table: views


### PR DESCRIPTION
This feature branch only changes the block id name that exists in the one view so that it actually finds the "Publisher Facet" block.