### PR TITLE
Revert UUID for ayout_builder.entity

### DIFF
--- a/config/install/core.entity_view_display.node.home_page.default.yml
+++ b/config/install/core.entity_view_display.node.home_page.default.yml
@@ -23,8 +23,8 @@ third_party_settings:
         layout_settings:
           label: Main
         components:
-          246ef0cf-cislandora_install_profile_democ-495a-bc56-c7468b172a81:
-            uuid: 246ef0cf-cislandora_install_profile_democ-495a-bc56-c7468b172a81
+          246ef0cf-cbdc-495a-bc56-c7468b172a81:
+            uuid: 246ef0cf-cbdc-495a-bc56-c7468b172a81
             region: content
             configuration:
               label_display: '0'


### PR DESCRIPTION
The UUID was invalid, so reverting to the previous value it was (which looks right) from what was changed.

Appears to be causing an issue with this PR https://github.com/Islandora-Devops/isle-dc/pull/248