### PR TITLE
Update to match latest Islandora Defaults

### DIFF
--- a/config/install/context.context.video.yml
+++ b/config/install/context.context.video.yml
@@ -15,7 +15,7 @@ conditions:
     negate: false
     context_mapping:
       node: '@node.node_route_context:node'
-    uri: 'https://github.com/Islandora/Crayfish/tree/dev/Homarus'
+    uri: 'http://purl.org/coar/resource_type/c_12ce'
     logic: and
 reactions:
   view_mode_alter:

--- a/migrate/tags.csv
+++ b/migrate/tags.csv
@@ -19,7 +19,7 @@ islandora_models,"Compound Object","A special type of collection where the paren
 islandora_models,"Newspaper","A special type of collection which only has Newspaper Issues for children.",https://schema.org/Newspaper
 islandora_display,"Open Seadragon","Display using the Open Seadragon viewer",http://openseadragon.github.io
 islandora_display,"PDFjs","Display using the PDF.js viewer",http://mozilla.github.io/pdf.js
-resource_types,"Collection","An aggregation of resources",http://purl.org/dc/dcmitype/Collection
+resource_types,"Collection","An aggregation of resources",http://purl.org/ontology/bibo/Collection
 resource_types,"Dataset","Data encoded in a defined structure",http://purl.org/dc/dcmitype/Dataset
 resource_types,"Image","A visual representation other than text",http://purl.org/dc/dcmitype/Image
 resource_types,"Interactive Resource","A resource requiring interaction from the user to be understood, executed, or experienced",http://purl.org/dc/dcmitype/InteractiveResource


### PR DESCRIPTION
Two contexts need updating:

1. Remote Video URI for Video term needs to be http://purl.org/coar/resource_type/c_12ce
2. Collection Context needs two unique URIs (http://purl.org/dc/dcmitype/Collection#Model is one, and http://purl.org/dc/dcmitype/Collection is the other)