### PR TITLE
Fix Collections View

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -99,7 +99,7 @@
         "drupal/config_suite": "^2.0",
         "drupal/config_update": "^1.7",
         "drupal/console": "dev-master",
-        "drupal/context": "4.x-dev#14c362a5c57457692cdb1335c24619e6ae76af94",
+        "drupal/context": "^4.1",
         "drupal/devel": "^4.1",
         "drupal/ds": "^3.13",
         "drupal/environment_indicator": "^4.0",

--- a/config/install/context.context.collection.yml
+++ b/config/install/context.context.collection.yml
@@ -2,6 +2,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - views.view.members
     - views.view.solr_search_content
   module:
     - islandora
@@ -56,7 +57,7 @@ reactions:
         third_party_settings:
           block_class:
             classes: ''
-    include_default_blocks: 0
+    include_default_blocks: 1
     saved: false
   view_mode_alter:
     id: view_mode_alter

--- a/config/install/views.view.home_page_featured_collections.yml
+++ b/config/install/views.view.home_page_featured_collections.yml
@@ -211,15 +211,6 @@ display:
           admin_label: 'field_model: Taxonomy term'
           plugin_id: standard
           required: false
-        field_resource_type:
-          id: field_resource_type
-          table: node__field_resource_type
-          field: field_resource_type
-          relationship: none
-          group_type: group
-          admin_label: 'field_resource_type: Taxonomy term'
-          plugin_id: standard
-          required: false
       header: {  }
       footer:
         area_text_custom:
@@ -307,7 +298,7 @@ display:
           id: field_external_uri_uri
           table: taxonomy_term__field_external_uri
           field: field_external_uri_uri
-          relationship: field_resource_type
+          relationship: field_model
           group_type: group
           admin_label: ''
           plugin_id: string
@@ -348,29 +339,10 @@ display:
           1: AND
       defaults:
         title: false
-        relationships: false
+        relationships: true
         filters: false
         filter_groups: false
         footer: false
-      relationships:
-        field_model:
-          id: field_model
-          table: node__field_model
-          field: field_model
-          relationship: none
-          group_type: group
-          admin_label: 'field_model: Taxonomy term'
-          plugin_id: standard
-          required: false
-        field_resource_type:
-          id: field_resource_type
-          table: node__field_resource_type
-          field: field_resource_type
-          relationship: none
-          group_type: group
-          admin_label: 'field_resource_type: Taxonomy term'
-          plugin_id: standard
-          required: false
       footer:
         area_text_custom:
           id: area_text_custom
@@ -436,3 +408,4 @@ display:
         - 'user.node_grants:view'
         - user.permissions
       tags: {  }
+

--- a/migrate/tags.csv
+++ b/migrate/tags.csv
@@ -1,22 +1,4 @@
 vid,name,description,external_uri
-islandora_media_use,"Extracted Text","A textual representation of the Object appropriate for fulltext indexing, such as a plaintext version of a document, or OCR text",http://pcdm.org/use#ExtractedText
-islandora_media_use,"Intermediate File","High quality representation of the Object, appropriate for generating derivatives or other additional processing",http://pcdm.org/use#IntermediateFile
-islandora_media_use,"Original File","The original creation format of a file",http://pcdm.org/use#OriginalFile
-islandora_media_use,"Preservation Master File","Best quality representation of the Object appropriate for long-term preservation",http://pcdm.org/use#PreservationMasterFile
-islandora_media_use,"Service File","A medium quality representation of the Object appropriate for serving to users",http://pcdm.org/use#ServiceFile
-islandora_media_use,"Thumbnail Image","A low resolution image representation of the Object appropriate for using as an icon",http://pcdm.org/use#ThumbnailImage
-islandora_media_use,"Transcript","A textual representation of the Object appropriate for presenting to users, such as subtitles or transcript of a video. Can be used as a substitute or complement to other files for accessibility purposes",http://pcdm.org/use#Transcript
-islandora_models,"Audio","A resource primarily intended to be heard. Examples include a music playback file format, an audio compact disc, and recorded speech or sounds",http://purl.org/coar/resource_type/c_18cc
-islandora_models,"Binary","A generic binary file for repository items that don't fall into any other category or cannot be shown in a browser",http://purl.org/coar/resource_type/c_1843
-islandora_models,"Collection","A collection is an aggregation of items",http://purl.org/dc/dcmitype/Collectiony#Moomoo
-islandora_models,"Image","A visual representation other than text, including all types of moving image and still image",http://purl.org/coar/resource_type/c_c513
-islandora_models,"Video","A recording of visual images, usually in motion and with sound accompaniment",http://purl.org/coar/resource_type/c_12ce
-islandora_models,"Digital Document","An electronic file or document.",https://schema.org/DigitalDocument
-islandora_models,"Paged Content","An Electronic Book, object with pages",https://schema.org/Book
-islandora_models,"Page","A page in an Electronic Paged Content Object",http://id.loc.gov/ontologies/bibframe/part
-islandora_models,"Publication Issue","A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.",https://schema.org/PublicationIssue
-islandora_models,"Compound Object","A special type of collection where the parent item may also have complex metadata",http://vocab.getty.edu/aat/300242735
-islandora_models,"Newspaper","A special type of collection which only has Newspaper Issues for children.",https://schema.org/Newspaper
 islandora_display,"Open Seadragon","Display using the Open Seadragon viewer",http://openseadragon.github.io
 islandora_display,"PDFjs","Display using the PDF.js viewer",http://mozilla.github.io/pdf.js
 resource_types,"Collection","An aggregation of resources",http://purl.org/ontology/bibo/Collection

--- a/migrate/tags.csv
+++ b/migrate/tags.csv
@@ -8,7 +8,7 @@ islandora_media_use,"Thumbnail Image","A low resolution image representation of 
 islandora_media_use,"Transcript","A textual representation of the Object appropriate for presenting to users, such as subtitles or transcript of a video. Can be used as a substitute or complement to other files for accessibility purposes",http://pcdm.org/use#Transcript
 islandora_models,"Audio","A resource primarily intended to be heard. Examples include a music playback file format, an audio compact disc, and recorded speech or sounds",http://purl.org/coar/resource_type/c_18cc
 islandora_models,"Binary","A generic binary file for repository items that don't fall into any other category or cannot be shown in a browser",http://purl.org/coar/resource_type/c_1843
-islandora_models,"Collection","A collection is an aggregation of items",http://purl.org/dc/dcmitype/Collection#Model
+islandora_models,"Collection","A collection is an aggregation of items",http://purl.org/dc/dcmitype/Collectiony#Moomoo
 islandora_models,"Image","A visual representation other than text, including all types of moving image and still image",http://purl.org/coar/resource_type/c_c513
 islandora_models,"Video","A recording of visual images, usually in motion and with sound accompaniment",http://purl.org/coar/resource_type/c_12ce
 islandora_models,"Digital Document","An electronic file or document.",https://schema.org/DigitalDocument
@@ -19,7 +19,7 @@ islandora_models,"Compound Object","A special type of collection where the paren
 islandora_models,"Newspaper","A special type of collection which only has Newspaper Issues for children.",https://schema.org/Newspaper
 islandora_display,"Open Seadragon","Display using the Open Seadragon viewer",http://openseadragon.github.io
 islandora_display,"PDFjs","Display using the PDF.js viewer",http://mozilla.github.io/pdf.js
-resource_types,"Collection","An aggregation of resources",http://purl.org/dc/dcmitype/Collection
+resource_types,"Collection","An aggregation of resources",http://purl.org/ontology/bibo/Collection
 resource_types,"Dataset","Data encoded in a defined structure",http://purl.org/dc/dcmitype/Dataset
 resource_types,"Image","A visual representation other than text",http://purl.org/dc/dcmitype/Image
 resource_types,"Interactive Resource","A resource requiring interaction from the user to be understood, executed, or experienced",http://purl.org/dc/dcmitype/InteractiveResource


### PR DESCRIPTION
Ticket: #31 

To test this, you MUST install this exact version (not update to it, etc). Use t[his branch of the sandbox](https://github.com/rosiel/islandora-sandbox/tree/2022-11-update) to deploy. (In its README there are testing instructions).

With this PR:
* The Collections view now filters on the core Model field, instead of the metadata-y Resource Types field.
* The Context for displaying Collections now 'includes default blocks' (it looked a little weird without it)
* The Context module's no longer locked to a specific commit, to fix a warning i was getting ([`Context module: "Menu Reactions" will not work because menu.active_trail has a different menu service provider.`](https://www.drupal.org/project/context/issues/3171741))
* For good measure (this is NOT active in the current install, see [ticket #31](https://github.com/Islandora-Devops/islandora_install_profile_demo/issues/31#issuecomment-1334103929) ), removed the core Islandora tags from this list, and corrected the Collection tag. This is so that we can use this file in the future if/when we remove Defaults.