### PR TITLE
Dependency fix - drupal/console was tagged 1.9.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -98,7 +98,7 @@
         "drupal/config_split": "^1.7",
         "drupal/config_suite": "^2.0",
         "drupal/config_update": "^1.7",
-        "drupal/console": "dev-master",
+        "drupal/console": "1.9.8",
         "drupal/context": "^4.1",
         "drupal/devel": "^4.1",
         "drupal/ds": "^3.13",


### PR DESCRIPTION
There was a long convo in Slack about this yesterday. Turns out some dependencies tagged some versions recently which put us in a bad spot. Switching drupal/console from `dev-main` to the tag corresponding to the currently used commit in the lockfile now allows `composer update` to run again. 

To test, run 
`composer require islandora/islandora_install_profile_demo dev-jan-2023-composer-update -W`

And then `composer update -W`. If you get a successful update of your modules without dependency errors, this is safe to merge. 